### PR TITLE
Fix primary color display bugs

### DIFF
--- a/DumbRequestManager/Classes/QueuedSong.cs
+++ b/DumbRequestManager/Classes/QueuedSong.cs
@@ -338,9 +338,9 @@ public class NoncontextualizedSong
 
     internal static string PrimaryTextColor => PluginConfig.Instance.PrimaryColor;
     internal static string SecondaryTextColor => PluginConfig.Instance.SecondaryColor;
-    internal static readonly string PrimaryGradient0 = $"{PrimaryTextColor}60";
-    internal static readonly string PrimaryGradient1 = $"{PrimaryTextColor}40";
-    internal static readonly string TransparentGradient = $"{PrimaryTextColor}00";
+    internal static string PrimaryGradient0 => $"{PrimaryTextColor}60";
+    internal static string PrimaryGradient1 => $"{PrimaryTextColor}40";
+    internal static string TransparentGradient => $"{PrimaryTextColor}00";
     // ReSharper restore MemberCanBePrivate.Global
     
     // https://github.com/TheBlackParrot/DumbRequestManager/issues/7#issue-3072545753 (ty Lack)

--- a/DumbRequestManager/UI/QueueViewController.cs
+++ b/DumbRequestManager/UI/QueueViewController.cs
@@ -1005,7 +1005,7 @@ internal class QueueViewController : BSMLAutomaticViewController
             {
                progress.ProgressChanged += (_, value) =>
                {
-                   _loadingSpinner.ShowDownloadingProgress($"Downloading map <color=#{Config.PrimaryColor}><b>{bsrKey}</b> <color=#FFFFFF80><size=80%>(<mspace=0.41em>{(value * 100):0}</mspace>%)", value);
+                   _loadingSpinner.ShowDownloadingProgress($"Downloading map <color={Config.PrimaryColor}><b>{bsrKey}</b> <color=#FFFFFF80><size=80%>(<mspace=0.41em>{(value * 100):0}</mspace>%)", value);
                };
             }
             


### PR DESCRIPTION
Fixes the accent coloring in the map download popup (by making it valid BSML), as well as the primary color gradient not reflecting any changes to the primary color without a full game restart.

This has not been tested, so probably do that before you press the shiny Merge button.

~~aw man it hurts writing colour without the u~~